### PR TITLE
removendo padding do container

### DIFF
--- a/style/main.scss
+++ b/style/main.scss
@@ -117,8 +117,7 @@ $desktop: 1200px;
 
     .container {
         width: 100%;
-        padding-right: 15px;
-        padding-left: 5px;
+				padding: 0px;
         margin-right: auto;
         margin-left: auto;
 


### PR DESCRIPTION
Foi removido o padding para poder ter melhor visualização no mobile conforme o arquivo enviando para mim.

Você precisa adicionar o padding na div col ou row (preferência na col).

**O arquivo não foi compilado.**